### PR TITLE
Makes in_care query different hopefully better.

### DIFF
--- a/app/models/query/in_care.rb
+++ b/app/models/query/in_care.rb
@@ -6,23 +6,12 @@ module Query
       @params = params
     end
 
-    def all
-      query
-        .select(:uac_id, :alien_no)
-        .limit(paginator.limit)
-        .offset(paginator.offset)
-    end
-
     def count
-      query.count
-    end
-
-    def query
-      Enrollment
-        .joins(:programs)
-        .where(uac_id: selection_ids)
-        .where('uac_info.uac_status in (?)',              in_care_statuses)
-        .where('uac_program_info.current_status in (?)',  in_care_statuses)
+      if date_parser.date_param == Date.today
+        enrollment_ids_via_status.count
+      else
+        greedy_selection_ids.count
+      end
     end
 
     private
@@ -31,23 +20,36 @@ module Query
       ["ADMITTED", "IN-TRANSFER", "ENROUTE"]
     end
 
-    def selection_ids
-      (enrollment_ids_with_no_exit + enrollment_ids_after_date).uniq
+    def greedy_selection_ids
+      (enrollment_ids_with_no_exit + enrollment_ids_after_date_with_exit).uniq
+    end
+
+    def enrollment_ids_via_status
+      Enrollment
+        .joins(:programs)
+        .where('uac_info.uac_status in (?)',              in_care_statuses)
+        .where('uac_program_info.current_status in (?)',  in_care_statuses)
+        .select(:uac_id)
+        .pluck(:uac_id)
     end
 
     def enrollment_ids_with_no_exit
       Enrollment
         .joins(:programs)
         .where("NOT EXISTS (SELECT uac_program_exit.uac_program_id FROM uac_program_exit WHERE uac_program_exit.uac_program_id = uac_program_info.uac_program_id)")
+        .where('uac_info.uac_status in (?)',              in_care_statuses)
+        .where('uac_program_info.current_status in (?)',  in_care_statuses)
         .select(:uac_id)
         .pluck(:uac_id)
     end
 
-    def enrollment_ids_after_date
+    def enrollment_ids_after_date_with_exit
       Enrollment
         .joins(:programs)
         .joins("INNER JOIN uac_program_exit AS program_exits ON uac_program_info.uac_program_id = program_exits.uac_program_id")
         .where('program_exits.date_of_discharge <  ?', date_parser.end_of_day)
+        .where('uac_info.uac_status = ?', "DISCHARGED")
+        .where('uac_program_info.current_status = ?', "DISCHARGED")
         .select(:uac_id)
         .pluck(:uac_id)
     end

--- a/spec/models/query/in_care_spec.rb
+++ b/spec/models/query/in_care_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+# Note: these are gold standard tests since we can't get any data
+# reliably into the database. And the multiple tests are really
+# spot checking.
+
+RSpec.describe Query::InCare, "#count" do
+  it 'gets a gold standard for a series of dates' do
+    expect(Query::InCare.new(on: '2016-07-20').count).to eq(5931)
+    expect(Query::InCare.new(on: '2016-05-15').count).to eq(5923)
+    expect(Query::InCare.new(on: '2015-07-15').count).to eq(5903)
+    expect(Query::InCare.new(on: '2015-01-01').count).to eq(5893)
+  end
+end
+


### PR DESCRIPTION
        Because of the way the query was set up before, it was always
the same number and base on the two statuses in the data.

        Changed query: if the date is today, it will just find all with
the correct statuses. Otherwise, it will find anything with an program exit
after that date and a status of DISCHARGED.

        The otherwise (not today) case is going to be greedy and get
things wrong, but the data does not exist either way.